### PR TITLE
INTER-2526: Bump pnpm to 11.26.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
   },
   "author": "FingerprintJS, Inc (https://fingerprint.com)",
   "license": "MIT",
-  "packageManager": "pnpm@11.13.0+sha512.88d94724d8f2e6c186744a5584c6e59ecac869ec7ba15e9cb4cd628e8dc7066820b2481d8ee3b51ea8da323a7378068aa58c556a3720d32b7c20a051d088363a",
+  "packageManager": "pnpm@11.26.0+sha512.fc0e2bf890b9f983611f1ab68c0637bce914390653699f83c1a78b005ed25f2c81e77920c8fd8eee2ecf0b58b28cdcb00a84d97f69bcf7c56b2f344710238664",
   "bugs": {
     "url": "https://github.com/fingerprintjs/react/issues"
   },


### PR DESCRIPTION
## What

Bumps the Corepack `packageManager` pin from `pnpm@11.13.0` to `pnpm@11.26.0`, the latest release on the v11 line. Staying on v11, no major-version jump.

## Why

pnpm 11.13.0 is on pnpm's [hardcoded broken-release list](https://github.com/pnpm/pnpm/blob/main/pnpm11/engine/pm/commands/src/self-updater/installPnpm.ts#L46), so newer pnpm refuses to install it outright:

```
ERR_PNPM_BROKEN_PNPM_RELEASE  pnpm v11.13.0 is a broken release and cannot be installed
```